### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,3 @@ require('typeface-open-sans');
     <App />
 </MuiThemeProvider>
 ```
->**NOTE:** Our React theme has been updated to use the new v2 Typography variants. You may see warning in your console output if you are still using the older variants. Read the [Migration Guide](https://material-ui.com/style/typography/#migration-to-typography-v2) to learn how to update your application.


### PR DESCRIPTION
Remove broken link for Typography variant migration. Migration period has ended and using the old variants will now be treated as errors instead of warnings.