### PR TITLE
Remove redundant fontWeight in RN theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "description": "PXBlue themes for Eaton applications",
     "main": "index.js",
     "scripts": {

--- a/react-native/dist/blueTheme.js
+++ b/react-native/dist/blueTheme.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.expoBlueTheme = exports.blueTheme = undefined;
+exports.blueTheme = undefined;
 
 var _colors = require('@pxblue/colors');
 
@@ -11,24 +11,24 @@ var blueTheme = exports.blueTheme = {
   roundness: 4,
   fonts: {
     extraBold: {
-      fontFamily: 'OpenSans-ExtraBold',
-      fontWeight: '800'
+      fontFamily: 'OpenSans-ExtraBold'
+      // fontWeight: '800'
     },
     bold: {
-      fontFamily: 'OpenSans-Bold',
-      fontWeight: '700'
+      fontFamily: 'OpenSans-Bold'
+      // fontWeight: '700'
     },
     semiBold: {
-      fontFamily: 'OpenSans-SemiBold',
-      fontWeight: '600'
+      fontFamily: 'OpenSans-SemiBold'
+      // fontWeight: '600'
     },
     regular: {
-      fontFamily: 'OpenSans-Regular',
-      fontWeight: '400'
+      fontFamily: 'OpenSans-Regular'
+      // fontWeight: '400'
     },
     light: {
-      fontFamily: 'OpenSans-Light',
-      fontWeight: '300'
+      fontFamily: 'OpenSans-Light'
+      // fontWeight: '300'
     }
   },
   colors: {
@@ -56,47 +56,3 @@ var blueTheme = exports.blueTheme = {
     
    This code is licensed under the BSD-3 license found in the LICENSE file in the root directory of this source tree and at https://opensource.org/licenses/BSD-3-Clause.
    **/
-
-var expoBlueTheme = exports.expoBlueTheme = {
-  roundness: 4,
-  fonts: {
-    extraBold: {
-      fontFamily: 'open-sans-extrabold',
-      fontWeight: '800'
-    },
-    bold: {
-      fontFamily: 'open-sans-bold',
-      fontWeight: '700'
-    },
-    semiBold: {
-      fontFamily: 'open-sans-semibold',
-      fontWeight: '600'
-    },
-    regular: {
-      fontFamily: 'open-sans-regular',
-      fontWeight: '400'
-    },
-    light: {
-      fontFamily: 'open-sans-light',
-      fontWeight: '300'
-    }
-  },
-  colors: {
-    primary: _colors.blue[500],
-    background: _colors.gray[50],
-    surface: _colors.white[50],
-    accent: _colors.lightBlue[500],
-    error: _colors.red[500],
-    text: _colors.gray[500],
-    onPrimary: _colors.white[50]
-  },
-  sizes: {
-    tiny: 10,
-    extraSmall: 12,
-    small: 14,
-    medium: 16,
-    large: 20,
-    extraLarge: 24,
-    giant: 34
-  }
-};

--- a/react-native/src/blueTheme.js
+++ b/react-native/src/blueTheme.js
@@ -14,68 +14,23 @@ export const blueTheme =
   fonts: {
     extraBold: {
       fontFamily: 'OpenSans-ExtraBold',
-      fontWeight: '800'
+      // fontWeight: '800'
     },
     bold: {
       fontFamily: 'OpenSans-Bold',
-      fontWeight: '700'
+      // fontWeight: '700'
     },
     semiBold: {
       fontFamily: 'OpenSans-SemiBold',
-      fontWeight: '600'
+      // fontWeight: '600'
     },
     regular: {
       fontFamily: 'OpenSans-Regular',
-      fontWeight: '400'
+      // fontWeight: '400'
     },
     light: {
       fontFamily: 'OpenSans-Light',
-      fontWeight: '300'
-    }
-  },
-  colors: {
-    primary: blue[500],
-    background: gray[50],
-    surface: white[50],
-    accent: lightBlue[500],
-    error: red[500],
-    text: gray[500],
-    onPrimary: white[50]
-  },
-  sizes: {
-    tiny: 10,
-    extraSmall: 12,
-    small: 14,
-    medium: 16,
-    large: 20,
-    extraLarge: 24,
-    giant: 34
-  }
-};
-
-export const expoBlueTheme =
-{
-  roundness: 4,
-  fonts: {
-    extraBold: {
-      fontFamily: 'open-sans-extrabold',
-      fontWeight: '800'
-    },
-    bold: {
-      fontFamily: 'open-sans-bold',
-      fontWeight: '700'
-    },
-    semiBold: {
-      fontFamily: 'open-sans-semibold',
-      fontWeight: '600'
-    },
-    regular: {
-      fontFamily: 'open-sans-regular',
-      fontWeight: '400'
-    },
-    light: {
-      fontFamily: 'open-sans-light',
-      fontWeight: '300'
+      // fontWeight: '300'
     }
   },
   colors: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes issue where Bold/SemiBold font style would render with the incorrect font (System) on Android devices. This appears to be caused by using the fontWeight property. The fontFamily property already incorporates the weight, so I removed the redundancy.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Remove the expoTheme (expo and vanilla are unified in a single theme)
- Remove the fontWeight definitions
