### PR TITLE
Change base from blue 500 to 'light'

### DIFF
--- a/storybook/index.js
+++ b/storybook/index.js
@@ -2,7 +2,7 @@ import { create } from '@storybook/theming/create';
 import * as colors from '@pxblue/colors';
 
 export const pxblueTheme = create({
-    base: colors.blue[500],
+    base: 'light',
 
     colorPrimary: colors.blue[500],
     colorSecondary: colors.white[500],


### PR DESCRIPTION
This should fix the dark / light theme issue

## Before
![image](https://user-images.githubusercontent.com/8997218/75782771-72d9a880-5d2d-11ea-8a9c-c61c6bec0e6d.png)


## After
![image](https://user-images.githubusercontent.com/8997218/75782698-50478f80-5d2d-11ea-9fda-42c44a509abe.png)

Look at the menu background color & tokens in the code snippet