### PR TITLE
Add theme for usermenu

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v5.1.0
 
--  Add UserMenu theme
+-   Add UserMenu theme
 
 ## v5.0.0
 

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v5.1.0
+
+-  Add UserMenu theme
+
 ## v5.0.0
 
 -   Update theme definitions to use the [@pxblue/colors](https://www.npmjs.com/package/@pxblue/colors) version 3.0.0.

--- a/angular/package.json
+++ b/angular/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/angular-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Angular themes for PX Blue applications",
     "scripts": {
         "start": "cd demo && yarn && cd .. && yarn link:themes && cd demo && yarn start",

--- a/angular/package.json
+++ b/angular/package.json
@@ -8,7 +8,7 @@
         "start": "cd demo && yarn && cd .. && yarn link:themes && cd demo && yarn start",
         "link:themes": "bash ./scripts/linkThemes.sh",
         "test": "bash ./scripts/buildTest.sh",
-        "prettier": "prettier \"*.scss\" --write"
+        "prettier": "prettier \"*.{scss,md}\" --write"
     },
     "repository": {
         "type": "git",

--- a/angular/pxb-component-theme.scss
+++ b/angular/pxb-component-theme.scss
@@ -9,6 +9,7 @@
     @include pxb-info-list-item-theme($theme);
     @include pxb-list-item-tag($theme);
     @include pxb-drawer($theme);
+    @include pxb-user-menu($theme);
 }
 
 @mixin pxb-score-card-theme($theme) {
@@ -99,5 +100,18 @@
         .pxb-info-list-item-active:after {
             background-color: map-get($primary, 50);
         }
+    }
+}
+
+@mixin pxb-user-menu($theme) {
+    $primary: map-get($theme, primary);
+    .pxb-user-menu-avatar {
+        background-color: map-get($primary, 50);
+        color: map-get($primary, 500);
+    }
+
+    .pxb-user-menu-overlay .mat-toolbar {
+        color: inherit;
+        background-color: inherit;
     }
 }


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- User Menu Theme

UserMenu uses primary[50] for avatar bg color, and primary[500] for color.
The Menu part uses a `mat-card` container with a `DrawerHeader` and `InfoListItem` items.   The avatar is only addition that needs a theme applied to it.  

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

Light: 
![image](https://user-images.githubusercontent.com/6538289/88190732-a21f8200-cc08-11ea-85dd-3ff86e99a089.png)


Dark: 
![image](https://user-images.githubusercontent.com/6538289/88193573-d0eb2780-cc0b-11ea-9183-7f3bdcedfadb.png)

