### PR TITLE
Remove manual font color

### DIFF
--- a/angular/_darkTheme.scss
+++ b/angular/_darkTheme.scss
@@ -60,11 +60,6 @@
         }
     }
 
-    /*list item*/
-    .mat-list-item-content {
-        color: map-get($foreground, text);
-    }
-
     /*Body*/
     .mat-drawer-content {
         background-color: map-get($pxb-darkBlack, 100);

--- a/angular/pxb-component-theme.scss
+++ b/angular/pxb-component-theme.scss
@@ -55,8 +55,9 @@
 }
 
 @mixin pxb-info-list-item-theme($theme) {
+    $foreground: map-get($theme, foreground);
     .pxb-info-list-item {
-        color: inherit;
+        color: map-get($foreground, text);
         &.mat-list-item,
         .mat-list-item-content {
             color: inherit;

--- a/angular/pxb-component-theme.scss
+++ b/angular/pxb-component-theme.scss
@@ -57,7 +57,8 @@
 @mixin pxb-info-list-item-theme($theme) {
     .pxb-info-list-item {
         color: inherit;
-        &.mat-list-item, .mat-list-item-content {
+        &.mat-list-item,
+        .mat-list-item-content {
             color: inherit;
         }
     }

--- a/angular/pxb-component-theme.scss
+++ b/angular/pxb-component-theme.scss
@@ -55,10 +55,9 @@
 }
 
 @mixin pxb-info-list-item-theme($theme) {
-    $foreground: map-get($theme, foreground);
     .pxb-info-list-item {
         color: inherit;
-        &.mat-list-item {
+        &.mat-list-item, .mat-list-item-content {
             color: inherit;
         }
     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes https://github.com/pxblue/angular-component-library/issues/120

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove manual fontColor on mat-list-item-content so that it will inherit color.
- Default color is already `map-get($foreground, text)`

This allows the text/icon colors in the angular showcase darkmode to appear.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

Before:
![image](https://user-images.githubusercontent.com/6538289/89661377-9f778a80-d8a0-11ea-8212-82638f7fe40d.png)


After:
![image](https://user-images.githubusercontent.com/6538289/89661178-56bfd180-d8a0-11ea-975e-d043e0828c3f.png)

