### PR TITLE
Light/Dark Ng-Stepper Theme Adjustments

### DIFF
--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -80,4 +80,12 @@
             border-color: map-get($accent, 500);
         }
     }
+
+    /* steppers */
+    .mat-step-header .mat-step-icon-state-done {
+        background-color: map-get($pxb-gray, 300);
+    }
+    .mat-step-header[aria-selected='true'] .mat-step-icon {
+        background-color: map-get($primary, 500);
+    }
 }

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -82,10 +82,20 @@
     }
 
     /* steppers */
-    .mat-step-header .mat-step-icon-state-done {
+    .mat-step-header .mat-step-icon-state-done,
+    .mat-step-icon.mat-step-icon-state-number,
+    .mat-step-icon.mat-step-icon-state-add {
         background-color: map-get($pxb-gray, 300);
     }
     .mat-step-header[aria-selected='true'] .mat-step-icon {
         background-color: map-get($primary, 500);
+    }
+    .mat-focus-indicator.mat-button-base.ng-star-inserted {
+        background-color: unset;
+    }
+    .mat-step-header {
+        &:hover, &.cdk-program-focused, &.cdk-mouse-focused, &.cdk-focused {
+            background-color: unset;
+        }
     }
 }

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -94,7 +94,10 @@
         background-color: unset;
     }
     .mat-step-header {
-        &:hover, &.cdk-program-focused, &.cdk-mouse-focused, &.cdk-focused {
+        &:hover,
+        &.cdk-program-focused,
+        &.cdk-mouse-focused,
+        &.cdk-focused {
             background-color: unset;
         }
     }

--- a/angular/_darkTheme.scss
+++ b/angular/_darkTheme.scss
@@ -89,11 +89,21 @@
         background-color: map-get($background, dialog);
         color: map-get($foreground, secondary-text);
     }
-    .mat-step-header .mat-step-icon-state-done {
+    .mat-step-header .mat-step-icon-state-done,
+    .mat-step-icon.mat-step-icon-state-number,
+    .mat-step-icon.mat-step-icon-state-add {
         background-color: map-get($pxb-gray, 300);
     }
     .mat-step-header[aria-selected='true'] .mat-step-icon {
         background-color: map-get($primary, 500);
+    }
+    .mat-focus-indicator.mat-button-base.ng-star-inserted {
+        background-color: unset;
+    }
+    .mat-step-header {
+        &:hover, &.cdk-program-focused, &.cdk-mouse-focused, &.cdk-focused {
+            background-color: unset;
+        }
     }
 
     /* table*/

--- a/angular/_darkTheme.scss
+++ b/angular/_darkTheme.scss
@@ -89,6 +89,12 @@
         background-color: map-get($background, dialog);
         color: map-get($foreground, secondary-text);
     }
+    .mat-step-header .mat-step-icon-state-done {
+        background-color: map-get($pxb-gray, 300);
+    }
+    .mat-step-header[aria-selected='true'] .mat-step-icon {
+        background-color: map-get($primary, 500);
+    }
 
     /* table*/
     .mat-table {

--- a/angular/_darkTheme.scss
+++ b/angular/_darkTheme.scss
@@ -101,7 +101,10 @@
         background-color: unset;
     }
     .mat-step-header {
-        &:hover, &.cdk-program-focused, &.cdk-mouse-focused, &.cdk-focused {
+        &:hover,
+        &.cdk-program-focused,
+        &.cdk-mouse-focused,
+        &.cdk-focused {
             background-color: unset;
         }
     }

--- a/angular/scripts/linkThemes.sh
+++ b/angular/scripts/linkThemes.sh
@@ -16,6 +16,7 @@ mkdir "./demos/showcase/node_modules/@pxblue/angular-themes"
 echo -e "${GREEN}Done${NC}"
 
 echo -en "${BLUE}Copying angular themes into node_modules...${NC}";
+# Showcase demo
 cp -r ./demos/showcase/package.json ./demos/showcase/node_modules/@pxblue/angular-themes/package.json
 cp -r ./_blueTheme.scss ./demos/showcase/node_modules/@pxblue/angular-themes/_blueTheme.scss
 cp -r ./_darkTheme.scss ./demos/showcase/node_modules/@pxblue/angular-themes/_darkTheme.scss
@@ -23,7 +24,17 @@ cp -r ./_fonts.scss ./demos/showcase/node_modules/@pxblue/angular-themes/_fonts.
 cp -r ./_margins.scss ./demos/showcase/node_modules/@pxblue/angular-themes/_margins.scss
 cp -r ./_typography.scss ./demos/showcase/node_modules/@pxblue/angular-themes/_typography.scss
 cp -r ./theme.scss ./demos/showcase/node_modules/@pxblue/angular-themes/theme.scss
-cp -r ./pxb-component-theme.scss ./demos/showcase/node_modules/@pxblue/angular-themes/pxb-component-theme.scss
+cp -r ./pxb-component-theme.scss ./demos/showcase/node_modules/@pxblue/angular-themes/pxb-component-theme.
+
+# Theme demo
+cp -r ./demos/showcase/package.json ./demos/theme/node_modules/@pxblue/angular-themes/package.json
+cp -r ./_blueTheme.scss ./demos/theme/node_modules/@pxblue/angular-themes/_blueTheme.scss
+cp -r ./_darkTheme.scss ./demos/theme/node_modules/@pxblue/angular-themes/_darkTheme.scss
+cp -r ./_fonts.scss ./demos/theme/node_modules/@pxblue/angular-themes/_fonts.scss
+cp -r ./_margins.scss ./demos/theme/node_modules/@pxblue/angular-themes/_margins.scss
+cp -r ./_typography.scss ./demos/theme/node_modules/@pxblue/angular-themes/_typography.scss
+cp -r ./theme.scss ./demos/theme/node_modules/@pxblue/angular-themes/theme.scss
+cp -r ./pxb-component-theme.scss ./demos/theme/node_modules/@pxblue/angular-themes/pxb-component-theme.scss
 
 echo -e "${GREEN}Done${NC}"
 


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- This makes only the active step in the stepper be blue[500]
- All other steps are now gray[300] for light/dark theme
- This theme removes strange highlight behavior when switching in-between steps or completing the stepper.