### PR TITLE
Feature/form field color adjustment

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2.1 (Not published)
+
+-   Adjust `<mat-form-field>` blue-theme colors.
+
 ## v5.2.0
 
 -   Add theme for `<pxb-mobile-stepper>`.

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -109,6 +109,12 @@
             background-color: map-get($pxb-white, 200);
         }
     }
+    .mat-form-field .mat-form-field-label {
+        color: map-get($pxb-black, 500);
+    }
+    .mat-form-field .mat-hint {
+        color: map-get($pxb-gray, 500);
+    }
 
     /* PXB Drawer */
     .pxb-drawer-nested-nav-item mat-expansion-panel {

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -115,6 +115,9 @@
     .mat-form-field .mat-hint {
         color: map-get($pxb-gray, 500);
     }
+    .mat-form-field-ripple {
+        background-color: map-get($pxb-black, 500);
+    }
 
     /* PXB Drawer */
     .pxb-drawer-nested-nav-item mat-expansion-panel {

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -115,8 +115,13 @@
     .mat-form-field .mat-hint {
         color: map-get($pxb-gray, 500);
     }
+
+    /* Mat Form Field hover ripple */
     .mat-form-field-ripple {
-        background-color: map-get($pxb-black, 500);
+        background-color: map-get($pxb-gray, 500);
+    }
+    .mat-form-field-appearance-outline .mat-form-field-outline-thick {
+        color: map-get($pxb-gray, 500);
     }
 
     /* PXB Drawer */

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -110,10 +110,10 @@
         }
     }
     .mat-form-field .mat-form-field-label {
-        color: map-get($pxb-black, 500);
+        color: map-get($foreground, text);
     }
     .mat-form-field .mat-hint {
-        color: map-get($pxb-gray, 500);
+        color: map-get($foreground, hint-text);
     }
 
     /* Mat Form Field hover ripple */
@@ -121,7 +121,7 @@
         background-color: map-get($pxb-gray, 500);
     }
     .mat-form-field-appearance-outline .mat-form-field-outline-thick {
-        color: map-get($pxb-gray, 500);
+        color: map-get($foreground, hint-text);
     }
 
     /* PXB Drawer */

--- a/angular/package.json
+++ b/angular/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/angular-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "5.2.0",
+    "version": "5.2.1",
     "description": "Angular themes for PX Blue applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #92 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Set `mat-form-field` label and text color to black[500]
- Set `mat-hint` text color to gray[500]
- Set the `mat-form-field` `mat-ripple` color to gray[500] (this is input field underline color on hover)

https://www.figma.com/file/ZwJ3feoFnLiV3JNYqI7A3c/PXBlue-DSM-Stickersheet?node-id=4650%3A1119

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/6538289/102355702-37d1fa00-3f7a-11eb-82ea-f5597fbe7109.png)

