### PR TITLE
Re-add less specific css rule to color navrail item

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   Fixed navigation rail active-item font-color bug. 
+-   Fixed navigation rail active-item font-color bug.
 
 ### Changed
 

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v5.2.1 (Not published)
 
+### Fixed
+
+-   Fixed navigation rail active-item font-color bug. 
+
 ### Changed
 
 -   Adjust `<mat-form-field>` blue-theme colors.

--- a/angular/_pxb-component-theme.scss
+++ b/angular/_pxb-component-theme.scss
@@ -104,7 +104,8 @@
             color: map-get($foreground, text);
         }
 
-        .pxb-drawer-nav-item-active .pxb-info-list-item .mat-list-item-content {
+        .pxb-drawer-nav-item-active, /*NavRail item*/
+        .pxb-drawer-nav-item-active .pxb-info-list-item .mat-list-item-content /*Normal NavItem*/ {
             color: map-get($primary, 500);
         }
 


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fixes nav rail active item not getting a blue[500] font color. 
> If drawer rail active item can change color to blue 500, then everything looks good style-wise.
> 
> ![image](https://user-images.githubusercontent.com/8997218/105866908-7b307700-5fc2-11eb-9573-6f9858a73a5d.png)

