### PR TITLE
Add score card badge background theme

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v6.0.0 (Not published)
 
+### Added
+
+-   Added `<pxb-score-card>` badge background theme. 
+
 ### Fixed
 
 -   Navigation rail active-item font-color bug.

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   Added `<pxb-score-card>` badge background theme. 
+-   Added `<pxb-score-card>` badge background theme.
 
 ### Fixed
 

--- a/angular/_pxb-component-theme.scss
+++ b/angular/_pxb-component-theme.scss
@@ -16,6 +16,7 @@
 @mixin pxb-score-card-theme($theme) {
     $primary: map-get($theme, primary);
     $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
     .pxb-score-card {
         .pxb-score-card-header {
             background-color: mat-color($primary);
@@ -23,6 +24,9 @@
             .mat-card-subtitle {
                 color: inherit;
             }
+        }
+        .pxb-hero-primary-wrapper {
+            background-color: mat-color($background, card);
         }
     }
 }


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- black[900] for dark 
- white[50] for light
- adds badge background color for PxbScoreCard

