### PR TITLE
Change *.66 line heights to *.67; Use REM font size

### DIFF
--- a/react/src/shared.ts
+++ b/react/src/shared.ts
@@ -22,19 +22,23 @@ export const typography = {
         fontWeight: 600,
     },
     body1: {
-        lineHeight: '1.5em',
+        lineHeight: '1.5',
     },
     body2: {
-        lineHeight: '1.43em',
+        lineHeight: '1.43',
     },
     button: {
         fontWeight: 600,
-        lineHeight: '1.75em',
+        lineHeight: '1.75',
     },
     overline: {
         letterSpacing: '2px',
-        fontSize: '12px',
+        fontSize: '0.75rem',
         fontWeight: 600,
+        lineHeight: '2.67',
+    },
+    caption: {
+        lineHeight: '1.67',
     },
 };
 export const createSimpleLightPalette = (color: PXBlueColor): SimplePaletteColorOptions => ({


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Change *.66 line-heights to *.67 (so that they actually round to proper integers)
- Use REM font size for overline 
- drop those "em"s in the lineHeight, since the lineHeight without those numbers are in em by default.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

I am trying to programmatically generate the chart in the typography page on docit, and I got some awkward results. By product of https://github.com/pxblue/doc-it/pull/365 
