### PR TITLE
Change default chip color

### DIFF
--- a/react/demos/theme/src/App.js
+++ b/react/demos/theme/src/App.js
@@ -1106,6 +1106,7 @@ export default () => {
                 </div>
                 <div>
                     <Avatar color={'primary'}>JB</Avatar>
+                    <Avatar color={'primary'}>JB</Avatar>
                     <Avatar color={'secondary'}>JB</Avatar>
                     <Avatar color={'error'}>JB</Avatar>
                 </div>

--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -343,6 +343,10 @@ export const blueTheme: ThemeOptions = {
                 '&$clickable:hover': {
                     backgroundColor: PXBColors.white[200],
                 },
+                '& $avatar': {
+                    backgroundColor: PXBColors.gray[500],
+                    marginRight: -4,
+                },
                 '& $avatarColorPrimary': {
                     backgroundColor: PXBColors.blue[100],
                     color: ThemeColors.primary.main,
@@ -353,10 +357,6 @@ export const blueTheme: ThemeOptions = {
                 },
                 '& $icon': {
                     marginLeft: Spacing,
-                    marginRight: -4,
-                },
-                '& $avatar': {
-                    // marginLeft: Spacing,
                     marginRight: -4,
                 },
                 '& $deleteIcon': {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Make outline chip default avatar color gray[500]

![image](https://user-images.githubusercontent.com/29152776/111678070-3f61a300-87f6-11eb-999d-8b49af79537c.png)
