### PR TITLE
Fix chip delete icon color

### DIFF
--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -335,7 +335,7 @@ export const blueTheme: ThemeOptions = {
             deleteIconOutlinedColorSecondary: {
                 color: PXBColors.lightBlue[200],
                 '&:hover': {
-                    color: ThemeColors.primary.main,
+                    color: ThemeColors.secondary.main,
                 },
             },
             outlined: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #163 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Secondary outline chip delete icon hover color should be secondary not primary