### PR TITLE
[#1] Prepare for React theme publication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,50 +36,22 @@ jobs:
                     name: Publish @pxblue/angular-themes
                     command:  |
                         cd angular
-                        MASTER_VERSION=`node -p "require('./package.json').version"`
-                        NPM_LATEST_VERSION=`npm show @pxblue/angular-themes version`
-                        if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
-                        then
-                            npm publish
-                        else
-                            echo "Latest version is already published."
-                        fi
+                        yarn publish:package
             -   run:
                     name: Publish @pxblue/react-themes
                     command:  |
                         cd react/dist
-                        MASTER_VERSION=`node -p "require('./package.json').version"`
-                        NPM_LATEST_VERSION=`npm show @pxblue/react-themes version`
-                        if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
-                        then
-                            npm publish
-                        else
-                            echo "Latest version is already published."
-                        fi
+                        yarn publish:package
             -   run:
                     name: Publish @pxblue/react-native-themes
                     command:  |
                         cd react-native
-                        MASTER_VERSION=`node -p "require('./package.json').version"`
-                        NPM_LATEST_VERSION=`npm show @pxblue/react-native-themes version`
-                        if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
-                        then
-                            npm publish
-                        else
-                            echo "Latest version is already published."
-                        fi
+                        yarn publish:package
             -   run:
                     name: Publish @pxblue/storybook-themes
                     command:  |
                         cd storybook
-                        MASTER_VERSION=`node -p "require('./package.json').version"`
-                        NPM_LATEST_VERSION=`npm show @pxblue/storybook-themes version`
-                        if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
-                        then
-                            npm publish
-                        else
-                            echo "Latest version is already published."
-                        fi
+                        yarn publish:package
 workflows:
     version: 2
     types:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             -   run:
                     name: Publish @pxblue/react-themes
                     command:  |
-                        cd react/dist
+                        cd react
                         yarn publish:package
             -   run:
                     name: Publish @pxblue/react-native-themes

--- a/angular/PUBLISHING.md
+++ b/angular/PUBLISHING.md
@@ -14,6 +14,6 @@ Alternatively, you can run:
 yarn publish:package
 ```
 
-which will automatically look at the version in `angular/package.json` and determine whether to publish an alpha, beta, or latest package.
+which will automatically look at the version in `angular/package.json` and determine whether to publish an alpha, beta, or latest package. For this command to work, you must have an NPM token configured in your environment variables or you can perform a login prior to executing the publish command via `npm adduser && yarn publish:package`.
 
 > The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/angular/PUBLISHING.md
+++ b/angular/PUBLISHING.md
@@ -4,8 +4,16 @@ To update the version number, edit the version in `angular/package.json`.
 
 To publish a new package through NPM, run the following commands from the root folder:
 
-```
+```sh
 npm publish --tag <alpha | beta>
 ```
 
-> The above command should only be run for `alpha` or `beta` packages. This repo's CircleCI will automatically publish latest packages from the master branch.
+Alternatively, you can run:
+
+```sh
+yarn publish:package
+```
+
+which will automatically look at the version in `angular/package.json` and determine whether to publish an alpha, beta, or latest package.
+
+> The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/angular/package.json
+++ b/angular/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/angular-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.0.0-beta.0",
+    "version": "6.0.0-beta.3",
     "description": "Angular themes for PX Blue applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",
@@ -11,6 +11,7 @@
         "link:themes": "bash ./scripts/linkThemes.sh",
         "test": "bash ./scripts/buildTest.sh",
         "prettier": "prettier \"**/**.{css,scss,html,md}\" --write",
+        "publish:package": "bash ./scripts/publish.sh",
         "precommit": "yarn initialize && yarn install:dependencies && yarn prettier && yarn test"
     },
     "repository": {

--- a/angular/scripts/publish.sh
+++ b/angular/scripts/publish.sh
@@ -1,0 +1,32 @@
+MASTER_VERSION=`node -p "require('./package.json').version"`
+NPM_LATEST_VERSION=`npm show @pxblue/angular-themes version`
+NPM_BETA_VERSION=`npm show @pxblue/angular-themes@beta version`
+NPM_ALPHA_VERSION=`npm show @pxblue/angular-themes@alpha version`
+
+if grep -q "alpha" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_ALPHA_VERSION ];
+    then
+        echo "Publishing new alpha";
+        npm publish --tag alpha
+    else
+        echo "Alpha version is already published."
+    fi
+elif grep -q "beta" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_BETA_VERSION ];
+    then
+        echo "Publishing new beta";
+        npm publish --tag beta
+    else
+        echo "Beta version is already published."
+    fi
+else
+    if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
+    then
+        echo "Publishing new latest";
+        npm publish
+    else
+        echo "Latest version is already published."
+    fi
+fi

--- a/react-native/CHANGELOG.md
+++ b/react-native/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v5.1.0 (Not Published Yet)
+## v5.1.0
 
 ### Added
 

--- a/react-native/PUBLISHING.md
+++ b/react-native/PUBLISHING.md
@@ -15,6 +15,6 @@ Alternatively, you can run:
 yarn publish:package
 ```
 
-which will automatically look at the version in `react-native/package.json` and determine whether to publish an alpha, beta, or latest package.
+which will automatically look at the version in `react-native/package.json` and determine whether to publish an alpha, beta, or latest package. For this command to work, you must have an NPM token configured in your environment variables or you can perform a login prior to executing the publish command via `npm adduser && yarn publish:package`.
 
 > The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/react-native/PUBLISHING.md
+++ b/react-native/PUBLISHING.md
@@ -9,4 +9,12 @@ yarn build
 npm publish --tag <alpha | beta>
 ```
 
-> The above command should only be run for `alpha` or `beta` packages. This repo's CircleCI will automatically publish latest packages from the master branch.
+Alternatively, you can run:
+
+```sh
+yarn publish:package
+```
+
+which will automatically look at the version in `react-native/package.json` and determine whether to publish an alpha, beta, or latest package.
+
+> The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -15,7 +15,8 @@
         "start:showcase-android": "yarn initialize && yarn install:showcase-android && cd demos/showcase && yarn android",
         "build": "yarn && tsc",
         "link:themes": "bash ./scripts/linkThemes.sh",
-        "test": "bash ./scripts/buildTest.sh"
+        "test": "bash ./scripts/buildTest.sh",
+        "publish:package": "bash ./scripts/publish.sh"
     },
     "repository": {
         "type": "git",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/react-native-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "5.1.0-beta.5",
+    "version": "5.1.0",
     "description": "React Native themes for PX Blue applications",
     "main": "./dist/index.js",
     "scripts": {

--- a/react-native/scripts/publish.sh
+++ b/react-native/scripts/publish.sh
@@ -1,0 +1,32 @@
+MASTER_VERSION=`node -p "require('./package.json').version"`
+NPM_LATEST_VERSION=`npm show @pxblue/react-native-themes version`
+NPM_BETA_VERSION=`npm show @pxblue/react-native-themes@beta version`
+NPM_ALPHA_VERSION=`npm show @pxblue/react-native-themes@alpha version`
+
+if grep -q "alpha" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_ALPHA_VERSION ];
+    then
+        echo "Publishing new alpha";
+        npm publish --tag alpha
+    else
+        echo "Alpha version is already published."
+    fi
+elif grep -q "beta" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_BETA_VERSION ];
+    then
+        echo "Publishing new beta";
+        npm publish --tag beta
+    else
+        echo "Beta version is already published."
+    fi
+else
+    if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
+    then
+        echo "Publishing new latest";
+        npm publish
+    else
+        echo "Latest version is already published."
+    fi
+fi

--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## v6.0.0 (Not published yet)
+## v6.0.0
 
 ### Changed
 

--- a/react/PUBLISHING.md
+++ b/react/PUBLISHING.md
@@ -16,6 +16,6 @@ Alternatively, you can run:
 yarn publish:package
 ```
 
-which will automatically look at the version in `react/package.json` and determine whether to publish an alpha, beta, or latest package.
+which will automatically look at the version in `react/package.json` and determine whether to publish an alpha, beta, or latest package. For this command to work, you must have an NPM token configured in your environment variables or you can perform a login prior to executing the publish command via `npm adduser && yarn publish:package`.
 
 > The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/react/PUBLISHING.md
+++ b/react/PUBLISHING.md
@@ -4,10 +4,18 @@ To update the version number, edit the version in `react/package.json`.
 
 To publish a new package through NPM, run the following commands from the root folder:
 
-```
+```sh
 yarn build
 cd dist
 npm publish --tag <alpha | beta>
 ```
 
-> The above command should only be run for `alpha` or `beta` packages. This repo's CircleCI will automatically publish latest packages from the master branch.
+Alternatively, you can run:
+
+```sh
+yarn publish:package
+```
+
+which will automatically look at the version in `react/package.json` and determine whether to publish an alpha, beta, or latest package.
+
+> The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/react/package.json
+++ b/react/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/react-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.0.0-beta.3",
+    "version": "6.0.0",
     "description": "React themes for PX Blue applications",
     "main": "index.js",
     "scripts": {
@@ -12,7 +12,8 @@
         "start:showcase": "yarn initialize && yarn install:dependencies && yarn link:themes && cd demos/showcase && yarn start",
         "build": "yarn && bash ./scripts/build.sh",
         "link:themes": "bash ./scripts/linkThemes.sh",
-        "test": "bash ./scripts/buildTest.sh"
+        "test": "bash ./scripts/buildTest.sh",
+        "publish:package": "bash ./scripts/publish.sh"
     },
     "repository": {
         "type": "git",

--- a/react/scripts/publish.sh
+++ b/react/scripts/publish.sh
@@ -1,3 +1,5 @@
+cd dist
+
 MASTER_VERSION=`node -p "require('./package.json').version"`
 NPM_LATEST_VERSION=`npm show @pxblue/react-themes version`
 NPM_BETA_VERSION=`npm show @pxblue/react-themes@beta version`

--- a/react/scripts/publish.sh
+++ b/react/scripts/publish.sh
@@ -1,0 +1,32 @@
+MASTER_VERSION=`node -p "require('./package.json').version"`
+NPM_LATEST_VERSION=`npm show @pxblue/react-themes version`
+NPM_BETA_VERSION=`npm show @pxblue/react-themes@beta version`
+NPM_ALPHA_VERSION=`npm show @pxblue/react-themes@alpha version`
+
+if grep -q "alpha" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_ALPHA_VERSION ];
+    then
+        echo "Publishing new alpha";
+        npm publish --tag alpha
+    else
+        echo "Alpha version is already published."
+    fi
+elif grep -q "beta" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_BETA_VERSION ];
+    then
+        echo "Publishing new beta";
+        npm publish --tag beta
+    else
+        echo "Beta version is already published."
+    fi
+else
+    if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
+    then
+        echo "Publishing new latest";
+        npm publish
+    else
+        echo "Latest version is already published."
+    fi
+fi

--- a/storybook/PUBLISHING.md
+++ b/storybook/PUBLISHING.md
@@ -8,4 +8,12 @@ To publish a new package through NPM, run the following commands from the root f
 npm publish --tag <alpha | beta>
 ```
 
-> The above command should only be run for `alpha` or `beta` packages. This repo's CircleCI will automatically publish latest packages from the master branch.
+Alternatively, you can run:
+
+```sh
+yarn publish:package
+```
+
+which will automatically look at the version in `storybook/package.json` and determine whether to publish an alpha, beta, or latest package.
+
+> The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/storybook/PUBLISHING.md
+++ b/storybook/PUBLISHING.md
@@ -14,6 +14,6 @@ Alternatively, you can run:
 yarn publish:package
 ```
 
-which will automatically look at the version in `storybook/package.json` and determine whether to publish an alpha, beta, or latest package.
+which will automatically look at the version in `storybook/package.json` and determine whether to publish an alpha, beta, or latest package. For this command to work, you must have an NPM token configured in your environment variables or you can perform a login prior to executing the publish command via `npm adduser && yarn publish:package`.
 
 > The above command should only be run manually for `alpha` or `beta` packages. Latest packages should only be published automatically by CircleCI once the code has been merged into the master branch.

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -7,7 +7,8 @@
     "main": "index.js",
     "types": "index.d.ts",
     "scripts": {
-        "test": "bash ./scripts/buildTest.sh"
+        "test": "bash ./scripts/buildTest.sh",
+        "publish:package": "bash ./scripts/publish.sh"
     },
     "repository": {
         "type": "git",

--- a/storybook/scripts/publish.sh
+++ b/storybook/scripts/publish.sh
@@ -1,0 +1,32 @@
+MASTER_VERSION=`node -p "require('./package.json').version"`
+NPM_LATEST_VERSION=`npm show @pxblue/storybook-themes version`
+NPM_BETA_VERSION=`npm show @pxblue/storybook-themes@beta version`
+NPM_ALPHA_VERSION=`npm show @pxblue/storybook-themes@alpha version`
+
+if grep -q "alpha" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_ALPHA_VERSION ];
+    then
+        echo "Publishing new alpha";
+        npm publish --tag alpha
+    else
+        echo "Alpha version is already published."
+    fi
+elif grep -q "beta" <<< "$MASTER_VERSION";
+then
+    if ! [ $MASTER_VERSION == $NPM_BETA_VERSION ];
+    then
+        echo "Publishing new beta";
+        npm publish --tag beta
+    else
+        echo "Beta version is already published."
+    fi
+else
+    if ! [ $MASTER_VERSION == $NPM_LATEST_VERSION ];
+    then
+        echo "Publishing new latest";
+        npm publish
+    else
+        echo "Latest version is already published."
+    fi
+fi


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove beta indication from react and react-native themes
- Update/simplify theme publication logic
    - CircleCI will now distinguish between alpha, beta, and latest packages
    - This means we can now merge code into master with the intent to publish a theme (e.g., react) without accidentally publishing the beta code for another theme (e.g., angular) as latest.
- Add new `publish:package` command that will automatically determine whether to publish an alpha, beta, or latest based on the version in package.json

> NOTE: I have already manually published @pxblue/react-themes@6.0.0 because I need the ball rolling for the other packages that depend on it.