### PR TITLE
Update icon and description colors for the Angular empty state component

### DIFF
--- a/angular/_darkTheme.scss
+++ b/angular/_darkTheme.scss
@@ -408,10 +408,6 @@
 
     /* PXB Empty State */
     .pxb-empty-state {
-        .pxb-empty-state-empty-icon-wrapper {
-            color: map-get($foreground, secondary-text);
-        }
-
         .pxb-empty-state-description {
             color: map-get($foreground, secondary-text);
         }

--- a/angular/_darkTheme.scss
+++ b/angular/_darkTheme.scss
@@ -409,11 +409,11 @@
     /* PXB Empty State */
     .pxb-empty-state {
         .pxb-empty-state-empty-icon-wrapper {
-            color: map-get($pxb-black, 200);
+            color: map-get($foreground, secondary-text);
         }
 
         .pxb-empty-state-description {
-            color: map-get($accent, 200);
+            color: map-get($foreground, secondary-text);
         }
     }
 

--- a/angular/_pxb-component-theme.scss
+++ b/angular/_pxb-component-theme.scss
@@ -37,8 +37,11 @@
     $foreground: map-get($theme, foreground);
     .pxb-empty-state {
         color: map-get($foreground, text);
+        .pxb-empty-state-empty-icon-wrapper {
+            color: map-get($foreground, secondary-text);
+        }
         .pxb-empty-state-description {
-            color: map-get($primary, 500);
+            color: map-get($foreground, text);
         }
     }
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes https://github.com/pxblue/angular-component-library/issues/240.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update icon and description colors for the Angular empty state component

![Screen Shot 2021-03-30 at 9 26 03 AM](https://user-images.githubusercontent.com/13989985/112996225-fdabf300-9139-11eb-9bd7-de8f782dfae4.png)
![Screen Shot 2021-03-30 at 9 25 54 AM](https://user-images.githubusercontent.com/13989985/112996227-fe448980-9139-11eb-9a78-71198d12db44.png)
