### PR TITLE
Fix mat toolbar styles

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v6.0.2
+
+### Fixed
+
+-   Fixed default `<pxb-drawer-header>` and `<pxb-dropdown-toolbar`> background color.
+
 ## v6.0.1
 
 ### Added

--- a/angular/_blueTheme.scss
+++ b/angular/_blueTheme.scss
@@ -99,17 +99,22 @@
 
     /* toolbar*/
     .mat-toolbar {
-        color: map-get($pxb-white, 50);
-        background-color: map-get($primary, 500);
+        color: map-get($foreground, text);
+        background-color: map-get($pxb-white, 50);
         &.mat-primary {
             background-color: map-get($primary, 500);
+            .mat-icon-button:not([color]) {
+                color: map-get($pxb-white, 50);
+            }
         }
         &.mat-accent {
             background-color: map-get($primary, 700);
+            .mat-icon-button:not([color]) {
+                color: map-get($pxb-white, 50);
+            }
         }
-        &:not([color]):not([ng-reflect-color]) {
-            color: map-get($foreground, text);
-            background-color: map-get($pxb-white, 50);
+        &.mat-warn .mat-icon-button:not([color]) {
+            color: map-get($pxb-white, 50);
         }
     }
 
@@ -321,9 +326,5 @@
     /*  Drawer Content */
     .mat-drawer-content {
         background-color: map-get($pxb-white, 200);
-    }
-
-    .mat-toolbar .mat-icon-button:not([color]) {
-        color: map-get($pxb-white, 50);
     }
 }

--- a/angular/_pxb-component-theme.scss
+++ b/angular/_pxb-component-theme.scss
@@ -104,11 +104,6 @@
     $foreground: map-get($theme, foreground);
     $background: map-get($theme, background);
     .pxb-drawer {
-        .pxb-drawer-header-content {
-            background-color: mat-color($primary);
-            color: map-get($pxb-white, 50);
-        }
-
         .pxb-drawer-nav-group .mat-list-base {
             color: map-get($foreground, text);
         }

--- a/angular/package.json
+++ b/angular/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/angular-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "description": "Angular themes for PX Blue applications",
     "scripts": {
         "initialize": "bash scripts/initializeSubmodule.sh",


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fixes Drawer header and Dropdown toolbar default styles
- Styles no longer rely on ng-generated metadata that is pruned in production mode

Can be viewed here: https://pxblue-angular-library.web.app/
^ This is ran in production mode, mimicking dev/prod deployments. 