### PR TITLE
React bug squash

### DIFF
--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v6.1.0 (June 28, 2021)
+
+### Changed
+
+-   Update auto-fill styles for MUI `<TextInput>`.
+-   Update styles for disabled MUI `<Switch>`.
+
 ## v6.0.0 (March 29, 2021)
 
 ### Changed

--- a/react/package.json
+++ b/react/package.json
@@ -2,7 +2,7 @@
     "name": "@pxblue/react-themes",
     "author": "PX Blue <pxblue@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "description": "React themes for PX Blue applications",
     "main": "index.js",
     "scripts": {

--- a/react/src/blueDarkTheme.ts
+++ b/react/src/blueDarkTheme.ts
@@ -83,7 +83,7 @@ export const blueDarkTheme: ThemeOptions = {
             },
             colorSecondary: {
                 color: ThemeColors.text.primary,
-                backgroundColor: PXBColors.black[900],
+                backgroundColor: ThemeColors.background.paper,
             },
         },
 
@@ -155,7 +155,7 @@ export const blueDarkTheme: ThemeOptions = {
                 },
                 '&$disabled': {
                     borderColor: Color(PXBColors.black[200]).alpha(0.36).string(),
-                    color: Color(PXBColors.black[300]).alpha(0.36).string(),
+                    color: ThemeColors.action.disabled,
                 },
             },
             outlinedPrimary: {
@@ -173,7 +173,7 @@ export const blueDarkTheme: ThemeOptions = {
                 },
                 '&$disabled': {
                     borderColor: Color(PXBColors.black[200]).alpha(0.36).string(),
-                    color: Color(PXBColors.black[300]).alpha(0.36).string(),
+                    color: ThemeColors.action.disabled,
                 },
             },
             contained: {
@@ -183,7 +183,7 @@ export const blueDarkTheme: ThemeOptions = {
                     backgroundColor: PXBColors.black[400],
                 },
                 '&$disabled': {
-                    backgroundColor: Color(PXBColors.black[200]).alpha(0.24).string(),
+                    backgroundColor: ThemeColors.action.disabledBackground,
                     color: PXBColors.black[400],
                 },
             },
@@ -209,10 +209,10 @@ export const blueDarkTheme: ThemeOptions = {
             },
             text: {
                 '&$disabled': {
-                    color: Color(PXBColors.black[300]).alpha(0.36).string(),
+                    color: ThemeColors.action.disabled,
                 },
                 '&:hover': {
-                    backgroundColor: Color(PXBColors.black[50]).alpha(0.1).string(),
+                    backgroundColor: ThemeColors.action.hover,
                 },
             },
             textPrimary: {
@@ -538,7 +538,7 @@ export const blueDarkTheme: ThemeOptions = {
                     color: ThemeColors.primary.dark,
                 },
                 '& .MuiButton-textSecondary': {
-                    color: PXBColors.lightBlue[500],
+                    color: ThemeColors.info.dark,
                 },
             },
         },
@@ -614,17 +614,48 @@ export const blueDarkTheme: ThemeOptions = {
             switchBase: {
                 color: ThemeColors.text.primary,
                 '&$checked + $track': {
-                    opacity: 0.5,
+                    opacity: 0.38,
+                },
+                '&$checked': {
+                    color: ThemeColors.secondary.main,
+                    '&$disabled': {
+                        color: '#4F7491',
+                    },
+                    '&$disabled + $track': {
+                        opacity: 0.24,
+                        backgroundColor: ThemeColors.secondary.main,
+                    },
                 },
             },
             colorPrimary: {
+                '&$disabled': {
+                    color: '#8E9294',
+                },
+                '&$disabled + $track': {
+                    backgroundColor: PXBColors.black[300],
+                },
                 '&$checked': {
                     color: ThemeColors.primary.main,
+                    '&$disabled': {
+                        color: '#4E7083',
+                    },
+                    '&$disabled + $track': {
+                        opacity: 1,
+                        backgroundColor: '#364B57',
+                    },
+                },
+            },
+            colorSecondary: {
+                '&$disabled': {
+                    color: '#8E9294',
+                },
+                '&$disabled + $track': {
+                    backgroundColor: PXBColors.black[300],
                 },
             },
             track: {
                 backgroundColor: PXBColors.black[300],
-                opacity: 0.36,
+                opacity: 0.38,
             },
             checked: {},
         },
@@ -645,19 +676,21 @@ export const blueDarkTheme: ThemeOptions = {
                 color: ThemeColors.text.primary,
                 backgroundColor: PXBColors.darkBlack[300],
                 '&$hover:hover': {
-                    backgroundColor: Color(PXBColors.darkBlack[300]).mix(Color(PXBColors.black[500]), 0.5).string(),
+                    backgroundColor: Color(PXBColors.darkBlack[300]).mix(Color(MediumBlackBackground), 0.5).string(),
                 },
                 '&:nth-of-type(odd):not($selected)': {
-                    backgroundColor: PXBColors.black[900],
+                    backgroundColor: ThemeColors.background.paper,
                     '&$hover:hover': {
-                        backgroundColor: Color(PXBColors.black[900]).mix(Color(PXBColors.black[500]), 0.5).string(),
+                        backgroundColor: Color(ThemeColors.background.paper)
+                            .mix(Color(MediumBlackBackground), 0.5)
+                            .string(),
                     },
                 },
                 '&$selected': {
                     backgroundColor: Color(ThemeColors.primary.dark).alpha(0.2).string(),
                     '&$hover:hover': {
                         backgroundColor: Color(ThemeColors.primary.dark)
-                            .mix(Color(PXBColors.black[500]), 0.5)
+                            .mix(Color(MediumBlackBackground), 0.5)
                             .alpha(0.2)
                             .string(),
                     },

--- a/react/src/blueDarkTheme.ts
+++ b/react/src/blueDarkTheme.ts
@@ -724,6 +724,10 @@ export const blueDarkTheme: ThemeOptions = {
                     color: PXBColors.black[300],
                     opacity: 0.36,
                 },
+                '&:-webkit-autofill': {
+                    '-webkit-box-shadow': `0 0 0 100px ${ThemeColors.background.paper} inset`,
+                    '-webkit-text-fill-color': ThemeColors.text.primary,
+                },
             },
             adornedStart: {},
             adornedEnd: {},
@@ -779,6 +783,11 @@ export const blueDarkTheme: ThemeOptions = {
                     pointerEvents: 'none',
                 },
             },
+            input: {
+                '&:-webkit-autofill': {
+                    '-webkit-box-shadow': `0 0 0 100px ${PXBColors.black[800]} inset`,
+                },
+            },
             underline: {
                 '&:before': {
                     borderBottomColor: ThemeColors.divider,
@@ -830,6 +839,11 @@ export const blueDarkTheme: ThemeOptions = {
                 },
                 '&$colorSecondary$focused $notchedOutline': {
                     borderColor: ThemeColors.secondary.dark,
+                },
+            },
+            input: {
+                '&:-webkit-autofill': {
+                    '-webkit-box-shadow': `0 0 0 100px ${ThemeColors.background.paper} inset`,
                 },
             },
             colorSecondary: {},

--- a/react/src/blueDarkTheme.ts
+++ b/react/src/blueDarkTheme.ts
@@ -538,7 +538,7 @@ export const blueDarkTheme: ThemeOptions = {
                     color: ThemeColors.primary.dark,
                 },
                 '& .MuiButton-textSecondary': {
-                    color: ThemeColors.info.dark,
+                    color: PXBColors.lightBlue[500],
                 },
             },
         },
@@ -876,7 +876,7 @@ export const blueDarkTheme: ThemeOptions = {
             },
             input: {
                 '&:-webkit-autofill': {
-                    '-webkit-box-shadow': `0 0 0 100px ${ThemeColors.background.paper} inset`,
+                    '-webkit-box-shadow': `0 0 0 100px ${PXBColors.black[900]} inset`,
                 },
             },
             colorSecondary: {},

--- a/react/src/blueDarkTheme.ts
+++ b/react/src/blueDarkTheme.ts
@@ -619,17 +619,16 @@ export const blueDarkTheme: ThemeOptions = {
                 '&$checked': {
                     color: ThemeColors.secondary.main,
                     '&$disabled': {
-                        color: '#4F7491',
+                        color: Color(ThemeColors.secondary.main).mix(Color(ThemeColors.background.paper), 0.5).string(),
                     },
                     '&$disabled + $track': {
-                        opacity: 0.24,
                         backgroundColor: ThemeColors.secondary.main,
                     },
                 },
             },
             colorPrimary: {
                 '&$disabled': {
-                    color: '#8E9294',
+                    color: Color(PXBColors.white[50]).mix(Color(ThemeColors.background.paper), 0.5).string(),
                 },
                 '&$disabled + $track': {
                     backgroundColor: PXBColors.black[300],
@@ -637,17 +636,19 @@ export const blueDarkTheme: ThemeOptions = {
                 '&$checked': {
                     color: ThemeColors.primary.main,
                     '&$disabled': {
-                        color: '#4E7083',
+                        color: Color(ThemeColors.primary.main).mix(Color(ThemeColors.background.paper), 0.5).string(),
                     },
                     '&$disabled + $track': {
-                        opacity: 1,
-                        backgroundColor: '#364B57',
+                        opacity: 0.38,
+                        backgroundColor: Color(ThemeColors.primary.main)
+                            .mix(Color(ThemeColors.background.paper), 0.5)
+                            .string(),
                     },
                 },
             },
             colorSecondary: {
                 '&$disabled': {
-                    color: '#8E9294',
+                    color: Color(PXBColors.white[50]).mix(Color(ThemeColors.background.paper), 0.5).string(),
                 },
                 '&$disabled + $track': {
                     backgroundColor: PXBColors.black[300],
@@ -657,7 +658,6 @@ export const blueDarkTheme: ThemeOptions = {
                 backgroundColor: PXBColors.black[300],
                 opacity: 0.38,
             },
-            checked: {},
         },
 
         // TABLE OVERRIDES

--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -629,9 +629,9 @@ export const blueTheme: ThemeOptions = {
         },
         MuiTableRow: {
             root: {
-                backgroundColor: '#FBFBFB', // possible new shade of white
+                backgroundColor: PXBColors.white[100],
                 '&$hover:hover': {
-                    backgroundColor: Color('#FBFBFB').mix(Color(PXBColors.black[50]), 0.5).string(),
+                    backgroundColor: Color(PXBColors.white[100]).mix(Color(PXBColors.black[50]), 0.5).string(),
                 },
                 '&:nth-of-type(odd):not($selected)': {
                     backgroundColor: ThemeColors.background.paper,

--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -73,16 +73,16 @@ export const blueTheme: ThemeOptions = {
         MuiAppBar: {
             colorDefault: {
                 color: ThemeColors.text.primary,
-                backgroundColor: PXBColors.white[50],
+                backgroundColor: ThemeColors.background.paper,
             },
             colorSecondary: {
-                color: PXBColors.white[50],
+                color: ThemeColors.background.paper,
                 backgroundColor: ThemeColors.primary.dark,
                 '& .MuiInputBase-root': {
-                    color: PXBColors.white[50],
+                    color: ThemeColors.background.paper,
                 },
                 '& .MuiSelect-icon': {
-                    color: PXBColors.white[50],
+                    color: ThemeColors.background.paper,
                 },
             },
         },
@@ -121,7 +121,7 @@ export const blueTheme: ThemeOptions = {
                 textTransform: 'none',
             },
             contained: {
-                backgroundColor: PXBColors.white[50],
+                backgroundColor: ThemeColors.background.paper,
                 color: ThemeColors.text.primary,
                 '&$disableElevation:not($containedPrimary):not($containedSecondary)': {
                     backgroundColor: PXBColors.white[500],
@@ -138,7 +138,7 @@ export const blueTheme: ThemeOptions = {
                 '&$disabled': {
                     backgroundColor: ThemeColors.background.paper,
                     border: `1px solid ${Color(PXBColors.black[500]).alpha(0.12).string()}`,
-                    color: Color(PXBColors.black[500]).alpha(0.3).string(),
+                    color: Color(ThemeColors.text.primary).alpha(0.3).string(),
                 },
             },
             containedPrimary: {
@@ -170,14 +170,14 @@ export const blueTheme: ThemeOptions = {
                 },
                 '&$disabled': {
                     backgroundColor: ThemeColors.background.paper,
-                    borderColor: Color(PXBColors.black[500]).alpha(0.12).string(),
-                    color: Color(PXBColors.black[500]).alpha(0.3).string(),
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
+                    color: Color(ThemeColors.text.primary).alpha(0.3).string(),
                 },
             },
             outlinedPrimary: {
                 borderColor: ThemeColors.primary.main,
                 '&$disabled': {
-                    borderColor: Color(PXBColors.black[500]).alpha(0.12).string(),
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
                 },
                 '&:hover': {
                     backgroundColor: Color(ThemeColors.primary.main).alpha(0.05).string(),
@@ -186,7 +186,7 @@ export const blueTheme: ThemeOptions = {
             outlinedSecondary: {
                 borderColor: ThemeColors.secondary.main,
                 '&$disabled': {
-                    borderColor: Color(PXBColors.black[500]).alpha(0.12).string(),
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
                 },
                 '&:hover': {
                     backgroundColor: Color(ThemeColors.secondary.main).alpha(0.05).string(),
@@ -263,7 +263,7 @@ export const blueTheme: ThemeOptions = {
                 },
                 '&$disabled': {
                     opacity: 1,
-                    color: Color(PXBColors.black[500]).alpha(0.3).string(),
+                    color: Color(ThemeColors.text.primary).alpha(0.3).string(),
                     '& $avatar': {
                         opacity: 0.5,
                     },
@@ -374,8 +374,8 @@ export const blueTheme: ThemeOptions = {
                 '&$disabled': {
                     opacity: 1,
                     backgroundColor: ThemeColors.background.paper,
-                    color: Color(PXBColors.black[500]).alpha(0.3).string(),
-                    borderColor: Color(PXBColors.black[500]).alpha(0.12).string(),
+                    color: ThemeColors.action.disabled,
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
                 },
             },
             outlinedSecondary: {
@@ -386,8 +386,8 @@ export const blueTheme: ThemeOptions = {
                 '&$disabled': {
                     opacity: 1,
                     backgroundColor: ThemeColors.background.paper,
-                    color: Color(PXBColors.black[500]).alpha(0.3).string(),
-                    borderColor: Color(PXBColors.black[500]).alpha(0.12).string(),
+                    color: ThemeColors.action.disabled,
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
                 },
             },
             icon: {
@@ -407,15 +407,15 @@ export const blueTheme: ThemeOptions = {
         MuiFab: {
             root: {
                 textTransform: 'none',
-                backgroundColor: PXBColors.white[50],
+                backgroundColor: ThemeColors.background.paper,
                 color: ThemeColors.text.primary,
                 '&:hover': {
                     backgroundColor: Color(PXBColors.black[500]).alpha(0.05).string(),
                 },
                 '&$disabled': {
                     backgroundColor: ThemeColors.background.paper,
-                    border: `1px solid ${Color(PXBColors.black[500]).alpha(0.12).string()}`,
-                    color: Color(PXBColors.black[500]).alpha(0.3).string(),
+                    border: `1px solid ${Color(BlackBorder).alpha(0.12).string()}`,
+                    color: ThemeColors.action.disabled,
                 },
             },
             primary: {
@@ -572,17 +572,48 @@ export const blueTheme: ThemeOptions = {
                 '&$checked + $track': {
                     opacity: 0.38,
                 },
+                '&$checked': {
+                    color: ThemeColors.secondary.main,
+                    '&$disabled': {
+                        color: '#80C3F8',
+                    },
+                    '&$disabled + $track': {
+                        opacity: 0.24,
+                        backgroundColor: ThemeColors.secondary.main,
+                    },
+                },
             },
             colorPrimary: {
+                '&$disabled': {
+                    color: ThemeColors.background.paper,
+                },
+                '&$disabled + $track': {
+                    backgroundColor: PXBColors.black[100],
+                },
                 '&$checked': {
                     color: ThemeColors.primary.main,
+                    '&$disabled': {
+                        color: '#7FBCDF',
+                    },
+                    '&$disabled + $track': {
+                        opacity: 1,
+                        backgroundColor: '#CFE6F3',
+                    },
+                },
+            },
+            colorSecondary: {
+                '&$disabled': {
+                    color: ThemeColors.background.paper,
+                },
+                '&$disabled + $track': {
+                    backgroundColor: PXBColors.black[100],
                 },
             },
             track: {
                 backgroundColor: PXBColors.black[100],
-                opacity: 1,
+                opacity: 0.38,
             },
-            checked: {},
+            disabled: {},
         },
 
         // TABLE OVERRIDES
@@ -603,9 +634,11 @@ export const blueTheme: ThemeOptions = {
                     backgroundColor: Color('#FBFBFB').mix(Color(PXBColors.black[50]), 0.5).string(),
                 },
                 '&:nth-of-type(odd):not($selected)': {
-                    backgroundColor: PXBColors.white[50],
+                    backgroundColor: ThemeColors.background.paper,
                     '&$hover:hover': {
-                        backgroundColor: Color(PXBColors.white[50]).mix(Color(PXBColors.black[50]), 0.5).string(),
+                        backgroundColor: Color(ThemeColors.background.paper)
+                            .mix(Color(PXBColors.black[50]), 0.5)
+                            .string(),
                     },
                 },
                 '&$selected': {
@@ -666,7 +699,7 @@ export const blueTheme: ThemeOptions = {
         },
         MuiTabs: {
             indicator: {
-                backgroundColor: PXBColors.white[50],
+                backgroundColor: ThemeColors.background.paper,
             },
         },
 
@@ -697,7 +730,7 @@ export const blueTheme: ThemeOptions = {
                 },
                 '&:not($disabled):hover:before': {
                     borderBottomWidth: 1,
-                    borderBottomColor: PXBColors.black[500],
+                    borderBottomColor: BlackBorder,
                 },
                 '&$disabled:before': {
                     borderBottomColor: ThemeColors.divider,
@@ -759,7 +792,7 @@ export const blueTheme: ThemeOptions = {
                     borderColor: ThemeColors.error.main,
                 },
                 '&$error:hover:not($focused) $notchedOutline': {
-                    borderColor: PXBColors.red[900],
+                    borderColor: ThemeColors.error.dark,
                 },
                 '&$disabled $notchedOutline': {
                     borderColor: ThemeColors.divider,

--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -682,6 +682,9 @@ export const blueTheme: ThemeOptions = {
                     color: PXBColors.black[100],
                     opacity: 1,
                 },
+                '&:-webkit-autofill': {
+                    '-webkit-box-shadow': `0 0 0 30px ${ThemeColors.background.paper} inset`,
+                },
             },
             adornedStart: {},
             adornedEnd: {},
@@ -722,6 +725,11 @@ export const blueTheme: ThemeOptions = {
                     color: Color(ThemeColors.text.primary).alpha(0.3).string(),
                     backgroundColor: PXBColors.white[100],
                     pointerEvents: 'none',
+                },
+            },
+            input: {
+                '&:-webkit-autofill': {
+                    '-webkit-box-shadow': `0 0 0 30px ${ThemeColors.background.default} inset`,
                 },
             },
             underline: {

--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -613,7 +613,6 @@ export const blueTheme: ThemeOptions = {
                 backgroundColor: PXBColors.black[100],
                 opacity: 0.38,
             },
-            disabled: {},
         },
 
         // TABLE OVERRIDES
@@ -716,7 +715,7 @@ export const blueTheme: ThemeOptions = {
                     opacity: 1,
                 },
                 '&:-webkit-autofill': {
-                    '-webkit-box-shadow': `0 0 0 30px ${ThemeColors.background.paper} inset`,
+                    '-webkit-box-shadow': `0 0 0 30px ${PXBColors.white[50]} inset`,
                 },
             },
             adornedStart: {},

--- a/react/src/blueTheme.ts
+++ b/react/src/blueTheme.ts
@@ -34,7 +34,7 @@ const ThemeColors = {
     text: {
         primary: PXBColors.black[500],
         secondary: PXBColors.gray[500],
-        // disabled: Color(PXBColors.black[300]).alpha(0.32).string(),
+        // disabled: Color(PXBColors.black[500]).alpha(0.3).string(),
         hint: PXBColors.gray[500],
     },
     action: {
@@ -575,10 +575,9 @@ export const blueTheme: ThemeOptions = {
                 '&$checked': {
                     color: ThemeColors.secondary.main,
                     '&$disabled': {
-                        color: '#80C3F8',
+                        color: Color(ThemeColors.secondary.main).mix(Color(ThemeColors.background.paper), 0.5).string(),
                     },
                     '&$disabled + $track': {
-                        opacity: 0.24,
                         backgroundColor: ThemeColors.secondary.main,
                     },
                 },
@@ -593,11 +592,13 @@ export const blueTheme: ThemeOptions = {
                 '&$checked': {
                     color: ThemeColors.primary.main,
                     '&$disabled': {
-                        color: '#7FBCDF',
+                        color: Color(ThemeColors.primary.main).mix(Color(ThemeColors.background.paper), 0.5).string(),
                     },
                     '&$disabled + $track': {
-                        opacity: 1,
-                        backgroundColor: '#CFE6F3',
+                        opacity: 0.38,
+                        backgroundColor: Color(ThemeColors.primary.main)
+                            .mix(Color(ThemeColors.background.paper), 0.5)
+                            .string(),
                     },
                 },
             },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2167.

#200 Using browser history to populate fields on auto-complete / auto-fill changes focus color of field
#192 React switch should stay blue when disabled
#158 Refactor hardcoded theme style/colors

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix input autofill styles
- Fix MuiSwitch styles
- Remove hardcoded color values

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- I have added TextField and Switch examples to the showcase to review these changes.
https://github.com/pxblue/react-showcase-demo/pull/16